### PR TITLE
Fix rotation bug and drag offset issue with deformed bubbles

### DIFF
--- a/js/managers/BubbleManager.js
+++ b/js/managers/BubbleManager.js
@@ -225,22 +225,25 @@ class BubbleManager {
     }
     
     applyBubbleStyles(bubbleContainer, x, y, width, height, rotation) {
-    Object.assign(bubbleContainer.style, {
-        position: 'absolute',
-        left: x + 'px',
-        top: y + 'px',
-        width: width + 'px',
-        height: height + 'px',
-        cursor: 'move',
-        transformOrigin: 'center center',
-        // Store rotation separately to avoid conflicts with deformation transforms
-        transform: `rotate(${rotation}deg)`,
-        zIndex: Constants.BUBBLE_Z_INDEX
-    });
-    
-    // Store rotation in a data attribute for later reference
-    bubbleContainer.setAttribute('data-rotation', rotation);
-}
+        Object.assign(bubbleContainer.style, {
+            position: 'absolute',
+            left: x + 'px',
+            top: y + 'px',
+            width: width + 'px',
+            height: height + 'px',
+            cursor: 'move',
+            transformOrigin: 'center center',
+            // Don't set transform here - let deformation manager handle it
+            zIndex: Constants.BUBBLE_Z_INDEX
+        });
+        
+        // Get bubble data to check if deformed
+        const bubbleData = this.getBubbleData(bubbleContainer);
+        if (bubbleData && !bubbleData.isDeformed) {
+            // Only set rotation if not deformed (deformation manager will handle combined transform)
+            bubbleContainer.style.transform = `rotate(${rotation}deg)`;
+        }
+    }
     
     createBubbleElementFromData(bubbleData) {
         const bubbleContainer = document.createElement('div');

--- a/js/managers/ControlPointManager.js
+++ b/js/managers/ControlPointManager.js
@@ -258,35 +258,35 @@ class ControlPointManager {
     }
     
     applyDeformationToBubble(bubbleElement, bubbleData) {
-    if (!bubbleElement || !bubbleData) return;
-    
-    if (!bubbleData.isDeformed) {
-        // Reset only deformation, keep rotation
-        const rotation = bubbleElement.getAttribute('data-rotation') || bubbleData.rotation || 0;
-        bubbleElement.style.transform = `rotate(${rotation}deg)`;
-        bubbleElement.style.transformOrigin = 'center center';
-        bubbleElement.innerHTML = Constants.BUBBLE_SVG;
-        return;
+        if (!bubbleElement || !bubbleData) return;
+        
+        if (!bubbleData.isDeformed) {
+            // Apply only rotation when not deformed
+            bubbleElement.style.transform = `rotate(${bubbleData.rotation || 0}deg)`;
+            bubbleElement.style.transformOrigin = 'center center';
+            bubbleElement.innerHTML = Constants.BUBBLE_SVG;
+            return;
+        }
+        
+        if (!bubbleElement.innerHTML.includes('xmlns')) {
+            bubbleElement.innerHTML = Constants.BUBBLE_SVG;
+        }
+        
+        const transformData = this.calculateCSSTransform(bubbleData);
+        
+        if (transformData.transformString) {
+            // Combine rotation with deformation transforms
+            const rotationTransform = `rotate(${bubbleData.rotation || 0}deg)`;
+            const combinedTransform = `${rotationTransform} ${transformData.transformString}`;
+            
+            bubbleElement.style.transformOrigin = transformData.transformOrigin;
+            bubbleElement.style.transform = combinedTransform;
+        } else {
+            // Apply only rotation if no deformation transform
+            bubbleElement.style.transform = `rotate(${bubbleData.rotation || 0}deg)`;
+            bubbleElement.style.transformOrigin = 'center center';
+        }
     }
-    
-    if (!bubbleElement.innerHTML.includes('xmlns')) {
-        bubbleElement.innerHTML = Constants.BUBBLE_SVG;
-    }
-    
-    const transformData = this.calculateCSSTransform(bubbleData);
-    
-    if (transformData.transformString) {
-        // Apply deformation and rotation together
-        const rotation = bubbleElement.getAttribute('data-rotation') || bubbleData.rotation || 0;
-        bubbleElement.style.transformOrigin = transformData.transformOrigin;
-        bubbleElement.style.transform = `rotate(${rotation}deg) ${transformData.transformString}`;
-    } else {
-        // No deformation, just rotation
-        const rotation = bubbleElement.getAttribute('data-rotation') || bubbleData.rotation || 0;
-        bubbleElement.style.transform = `rotate(${rotation}deg)`;
-        bubbleElement.style.transformOrigin = 'center center';
-    }
-}
     
     resetControlPoints(bubbleData) {
         bubbleData.controlPoints = { ...Constants.DEFAULT_CONTROL_POINTS };
@@ -294,7 +294,8 @@ class ControlPointManager {
         bubbleData.deformationMatrix = null;
         
         if (bubbleData.element) {
-            bubbleData.element.style.transform = '';
+            // Preserve rotation when resetting
+            bubbleData.element.style.transform = `rotate(${bubbleData.rotation || 0}deg)`;
             bubbleData.element.style.transformOrigin = 'center center';
             bubbleData.element.innerHTML = Constants.BUBBLE_SVG;
         }


### PR DESCRIPTION
- Fixed rotation not preserving deformation state during transforms
- Fixed bubble position jumping when dragging deformed/re-selected bubbles
- Fixed Ctrl+R to always prevent page refresh and only reset selected bubbles
- Fixed click-outside deselection by correcting background-image ID check

Changes:
- ControlPointManager: Combined rotation with deformation transforms
- BubbleManager: Removed direct transform application in applyBubbleStyles
- InteractionManager: Use stored position for drag offset calculation instead of visual bounds